### PR TITLE
(bugfix) : fix  prometheus timeseries entries

### DIFF
--- a/aw-sync-agent/datamanager/datamanager.go
+++ b/aw-sync-agent/datamanager/datamanager.go
@@ -116,7 +116,6 @@ func AggregateData(events []aw.Event, watcher string, userID string, includeHost
 
 		timeSeriesList = append(timeSeriesList, timeSeries)
 	}
-	fmt.Print(timeSeriesList)
 	return timeSeriesList
 }
 

--- a/aw-sync-agent/datamanager/datamanager.go
+++ b/aw-sync-agent/datamanager/datamanager.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"sort"
 	"strconv"
-	"strings"
 )
 
 // ScrapeData scrapes the data from the local ActivityWatch instance via the aw Client
@@ -89,21 +88,21 @@ func AggregateData(events []aw.Event, watcher string, userID string, includeHost
 		}
 		var labels []prometheus.Label
 
-		util.AddMetricLabel(labels, "__name__", strings.ReplaceAll(watcher, "-", "_")) //Watcher name
-		util.AddMetricLabel(labels, "unique_id", util.GetRandomUUID())                 // Unique ID for each event to avoid duplicate errors of timestamp seconds
-		util.AddMetricLabel(labels, "aw_id", strconv.Itoa(event.ID))                   //Event ID created from activityWatch
-		util.AddMetricLabel(labels, "user", userID)
+		util.AddMetricLabel(&labels, "__name__", util.SanitizeLabelName(watcher)) //Watcher name
+		util.AddMetricLabel(&labels, "unique_id", util.GetRandomUUID())           // Unique ID for each event to avoid duplicate errors of timestamp seconds
+		util.AddMetricLabel(&labels, "aw_id", strconv.Itoa(event.ID))             //Event ID created from activityWatch
+		util.AddMetricLabel(&labels, "user", userID)
 
 		hostValue := "Unknown"
 		if includeHostName {
 			hostValue = util.GetHostname()
 		}
 
-		util.AddMetricLabel(labels, "host", hostValue)
+		util.AddMetricLabel(&labels, "host", hostValue)
 
 		// Add the data as labels
 		for key, value := range event.Data {
-			util.AddMetricLabel(labels, key, fmt.Sprintf("%v", value))
+			util.AddMetricLabel(&labels, key, fmt.Sprintf("%v", value))
 		}
 		sample := prometheus.Sample{
 			Value: event.Duration,
@@ -117,7 +116,7 @@ func AggregateData(events []aw.Event, watcher string, userID string, includeHost
 
 		timeSeriesList = append(timeSeriesList, timeSeries)
 	}
-
+	fmt.Print(timeSeriesList)
 	return timeSeriesList
 }
 

--- a/aw-sync-agent/util/prometheus_util.go
+++ b/aw-sync-agent/util/prometheus_util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"time"
 )
 
@@ -53,11 +54,17 @@ func MakeRequest(url string, secretKey string) (*http.Response, error) {
 	return resp, nil
 }
 
-func AddMetricLabel(labels []prometheus.Label, key string, value string) {
+func AddMetricLabel(labels *[]prometheus.Label, key string, value string) {
 	if value != "" {
-		labels = append(labels, prometheus.Label{
+		*labels = append(*labels, prometheus.Label{
 			Name:  key,
 			Value: value,
 		})
 	}
+}
+
+// SanitizeLabelName ensures the label name conforms to Prometheus naming conventions
+func SanitizeLabelName(name string) string {
+	re := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	return re.ReplaceAllString(name, "_")
 }


### PR DESCRIPTION
This pull request includes several changes to the `aw-sync-agent` to improve data management and label handling. The most important changes include modifying the `AggregateData` function to use pointers for label handling, adding a new utility function for label sanitization, and removing an unused import.

Improvements to label handling:

* [`aw-sync-agent/datamanager/datamanager.go`](diffhunk://#diff-46fde0f5fec4f78230dc94ed235cad85e4f430f1cba46cf803c7dfd884bbfb68L92-R105): Modified the `AggregateData` function to use pointers for the `labels` parameter in `util.AddMetricLabel` calls.
* [`aw-sync-agent/util/prometheus_util.go`](diffhunk://#diff-7bc1b9adc58777107e8d578182d526df12bf2a903cd980e10f5b3c1b34d2aa0bL56-R70): Changed the `AddMetricLabel` function to accept a pointer to the `labels` slice and added a new `SanitizeLabelName` function to ensure label names conform to Prometheus naming conventions.

Code cleanup:

* [`aw-sync-agent/datamanager/datamanager.go`](diffhunk://#diff-46fde0f5fec4f78230dc94ed235cad85e4f430f1cba46cf803c7dfd884bbfb68L15): Removed the unused `strings` import.


Additional utility:

* [`aw-sync-agent/util/prometheus_util.go`](diffhunk://#diff-7bc1b9adc58777107e8d578182d526df12bf2a903cd980e10f5b3c1b34d2aa0bR9): Added a new import for `regexp` to support the `SanitizeLabelName` function.